### PR TITLE
[F] Use filepath from Webpack

### DIFF
--- a/components/WebpackAssets.php
+++ b/components/WebpackAssets.php
@@ -102,9 +102,7 @@ class WebpackAssets extends ComponentBase {
         }
 
         $assetListVar = "${prop}Files";
-        return $this->prependAssetsFolder(
-            $manifestClass::$$assetListVar
-        );
+        return $manifestClass::$$assetListVar;
     }
 
     /**

--- a/components/WebpackAssets.php
+++ b/components/WebpackAssets.php
@@ -106,16 +106,6 @@ class WebpackAssets extends ComponentBase {
     }
 
     /**
-     * @param array $filenames
-     * @return array
-     */
-    protected function prependAssetsFolder($filenames = []) {
-        return array_map(function ($item) {
-            return $this->assetsFolder() . DIRECTORY_SEPARATOR . $item;
-        }, $filenames);
-    }
-
-    /**
      * @param $manifestFilename
      * @return string
      */


### PR DESCRIPTION
Based on webpack-php-manifest pull request #1
https://github.com/gblair/webpack-php-manifest/pull/1

The pr features assume the webpack user will pass the relative
asset path required. This feature prevents the default asset folder
(or indeed an optional one) from being added to the files before
including. The asset folder in this plugin in this component is still
required so that October can find the webpack manifest in the build
files.