### PR TITLE
[F] Add support for preloading font assets

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -17,7 +17,7 @@ class Plugin extends PluginBase
     {
         return [
             'name'        => 'WebpackPhpManifest',
-            'description' => 'Include CSS and JS assets built using the nodejs module "php-manifest-webpack-plugin"',
+            'description' => 'Include CSS, JS, and font assets built using the nodejs module "php-manifest-webpack-plugin"',
             'author'      => 'Gabe Blair <gabe@castironcoding.com>',
             'icon'        => 'icon-leaf'
         ];

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 ## Webpack Assets in October CMS
 
-This plugin for OctoberCMS works in tandem with the node package `webpack-assets-manifest` 
-(https://github.com/webdeveric/webpack-assets-manifest) to include CSS and JS
+This plugin for OctoberCMS works in tandem with the node package `webpack-assets-manifest`
+(https://github.com/webdeveric/webpack-assets-manifest) to include CSS, JS, and font assets
  in your site based on a JSON manifest file written to your assets directory. This will allow you to use hashed file
  names in your built files, and let October pick up the paths effortlessly.
- 
- In non-development environments (when the APP_ENV environment variable doesn't equal "dev") these paths get cached 
+
+ In non-development environments (when the APP_ENV environment variable doesn't equal "dev") these paths get cached
  so the JSON file isn't read on every request. This cache should be cleared as a part of the deploy process by running
  `php artisan cache:clear`.
- 
+
 ### Installation
 
 ```
@@ -18,11 +18,14 @@ composer require castiron/webpackassets-plugin
 ### Quick start
 
 This plugin provides a component called `webpackAssets`. Include the component in your view and then use the following
- to include the js/css in your template (e.g. in a partial, layout, etc.):
- 
+ to include the js/css/fonts (WOFF2 only) in your template (e.g. in a partial, layout, etc.):
+
 ```html
 [webpackAssets]
 ==
+
+<!-- include font <link rel="preload"> tags: -->
+{{ webpackAssets.tag('unhashed_filename.woff2') | raw }}
 
 <!-- include css <link> tags: -->
 {{ webpackAssets.tag('unhashed_filename.css') | raw }}
@@ -38,12 +41,16 @@ This plugin provides a component called `webpackAssets`. Include the component i
 {{ webpackAssets.tag('webpack-dev-server.js') | raw }}
 ```
 
+Keep in mind that there’s a performance trade-off to preloading too many font assets,
+so limit your use to only the highest-priority font assets. For the same reason, the plugin will
+only create tags for the WOFF2 font format. (See [“The Critical Request”](https://calibreapp.com/blog/critical-request/) and [“The Web Fonts: Preloaded”](https://www.zachleat.com/web/preload/) for more information.)
+
 ### Component options
- 
+
 `publicFolder` (default: "www")
 
 
-If you are [using a public folder in 
+If you are [using a public folder in
  OctoberCMS](https://octobercms.com/docs/setup/configuration#public-folder) (you should be!), specify it here. E.g.
  "www" or "public"
 
@@ -68,5 +75,3 @@ assetsFolder = assets
 [webpackAssets]
 manifestFilename = files.json
 ```
-
-

--- a/components/WebpackAssets.php
+++ b/components/WebpackAssets.php
@@ -20,7 +20,7 @@ class WebpackAssets extends ComponentBase
     {
         return [
             'name' => 'Webpack assets',
-            'description' => 'Render Javascript/CSS includes for webpack assets'
+            'description' => 'Render Javascript/CSS/font includes for webpack assets'
         ];
     }
 
@@ -156,6 +156,9 @@ class WebpackAssets extends ComponentBase
             case 'js':
                 return $this->getJsTag($filePath);
                 break;
+            case 'woff2':
+                return $this->getFontTag($filePath, @$matches[1]);
+                break;
         }
         return '';
     }
@@ -176,5 +179,14 @@ class WebpackAssets extends ComponentBase
     protected function getJsTag($path)
     {
         return '<script type="text/javascript" src="' . $path . '"></script>';
+    }
+
+    /**
+     * @param $path
+     * @return string
+     */
+    protected function getFontTag($path, $ext)
+    {
+        return '<link rel="preload" as="font" type="font/' . $ext . '" href="' . $path . '" crossorigin="anonymous">';
     }
 }


### PR DESCRIPTION
This PR adds support for generating a `<link rel="preload">` tag for WOFF2 font assets. `preload` allows for prioritizing load of critical font assets at the top of the document, rather than after CSS
is parsed and applied.